### PR TITLE
Add refactored version using slow_enumerator_tools

### DIFF
--- a/ruby/refactor-b.rb
+++ b/ruby/refactor-b.rb
@@ -1,0 +1,30 @@
+require 'slow_enumerator_tools'
+
+def buf(input)
+  SlowEnumeratorTools.buffer(input, 10)
+end
+
+def ls(options = {})
+  open("| ls #{'-l' if options[:long]}").each.lazy.map do |l|
+    puts "Reading #{l.inspect}"
+    l
+  end
+end
+
+def grep(input, regex)
+  buf(input).select do |l|
+    puts "Filtering #{l.inspect}"
+    l =~ regex
+  end
+end
+
+def count(input)
+  total = 0
+  buf(input).each do |l|
+    puts "Counting #{l.inspect}"
+    total += 1
+  end
+  total
+end
+
+p count(grep(ls(long: true), /^-.{8}x/))


### PR DESCRIPTION
This adds `refactor-b.rb`, which is like `refactor.rb` but uses `slow_enumerator_tools` (with a `#buf` helper function because it makes things a bit easier).

It’s shorter, and also prevents in-between from blowing up.

FYI: `#buf` is only useful to be called when the operation itself is slow (e.g. if `#count` were to `sleep 0.1` in between lines, having `buf(input)` instead of just `input` makes sense… but otherwise it doesn’t.)